### PR TITLE
Bump dependencies and enforce locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     },
     "scripts": {
         "dist": "npm pack",
-        "test": "node test/testSuite.js",
-        "debug": "node --inspect-brk test/testSuite.js",
+        "test": "LANG=en-US node test/testSuite.js",
+        "debug": "LANG=en-US node --inspect-brk test/testSuite.js",
         "clean": "git clean -f -d *"
     },
     "engines": {
@@ -52,7 +52,7 @@
     },
     "dependencies": {
         "ilib": "^14.1.0",
-        "log4js": "^2.11.0"
+        "log4js": "^5.0.0"
     },
     "devDependencies": {
         "loctool": "^2.1.0",


### PR DESCRIPTION
* Bumps log4js to 5.0.0 to fix security issues
* Force locale to `en-US` in tests

Todos:

* Bump `loctool` dependency once new version has shipped
* Update dependency on this package in `ilib-loctool-javascript`
