### PR TITLE
Fix getExtracted to return an empty set

### DIFF
--- a/JavaScriptResourceFileType.js
+++ b/JavaScriptResourceFileType.js
@@ -37,6 +37,10 @@ var JavaScriptResourceFileType = function(project) {
     this.API = project.getAPI();
 
     this.extensions = [ ".js" ];
+
+    this.extracted = this.API.newTranslationSet(project.getSourceLocale());
+    this.newres = this.API.newTranslationSet(project.getSourceLocale());
+    this.pseudo = this.API.newTranslationSet(project.getSourceLocale());
 };
 
 /*

--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 ilib-loctool-javascript-resource is a plugin for the loctool that
 allows it to read and localize javascript resource files.
 
+## Release Notes
+
+v1.0.1
+
+Fixed bug where JavscriptResourceFileType.getExtracted and getNew and getPseudo were returning
+undefined instead of an empty translation set.
+
+v1.0.0
+
+Initial release
+
 ## License
 
 Copyright © 2019, JEDLSoft

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-javascript-resource",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./JavaScriptResourceFileType.js",
     "description": "A loctool plugin that knows how to process JS resource files",
     "license": "Apache-2.0",


### PR DESCRIPTION
Fixed bug where JavscriptResourceFileType.getExtracted and getNew and getPseudo were returning undefined instead of an empty translation set.
