### PR TITLE
Resolve unit test problems

### DIFF
--- a/JavaScriptResourceFile.js
+++ b/JavaScriptResourceFile.js
@@ -41,6 +41,7 @@ var JavaScriptResourceFile = function(props) {
         this.pathName = props.pathName;
         this.locale = new Locale(props.locale);
         this.API = props.project.getAPI();
+        this.type = props.type;
     }
 
     this.logger = this.API.getLogger("loctool.plugin.JavaScriptResourceFile");

--- a/JavaScriptResourceFileType.js
+++ b/JavaScriptResourceFileType.js
@@ -89,12 +89,12 @@ JavaScriptResourceFileType.prototype.name = function() {
  * @return {JavaScriptResourceFile} a resource file instance for the
  * given path
  */
-JavaScriptResourceFileType.prototype.newFile = function(pathName) {
+JavaScriptResourceFileType.prototype.newFile = function(pathName, options) {
     var file = new JavaScriptResourceFile({
         project: this.project,
         pathName: pathName,
         type: this,
-        API: this.API
+        locale: options.locale
     });
 
     var locale = file.getLocale() || this.project.sourceLocale;
@@ -109,18 +109,23 @@ JavaScriptResourceFileType.prototype.newFile = function(pathName) {
  *
  * @param {String} locale the name of the locale in which the resource
  * file will reside
+ * @param {String} pathName the optional path to the resource file if the
+ * caller has already calculated what it should be 
  * @return {JavaScriptResourceFile} the Android resource file that serves the
  * given project, context, and locale.
  */
-JavaScriptResourceFileType.prototype.getResourceFile = function(locale) {
-    var key = locale || this.project.sourceLocale;
+JavaScriptResourceFileType.prototype.getResourceFile = function(locale, pathName) {
+    var loc = locale || this.project.sourceLocale;
+    var key = [loc, pathName].join("_");
 
     var resfile = this.resourceFiles && this.resourceFiles[key];
 
     if (!resfile) {
         resfile = this.resourceFiles[key] = new JavaScriptResourceFile({
             project: this.project,
-            locale: key
+            locale: loc,
+            pathName: pathName,
+            type: this
         });
 
         this.logger.trace("Defining new resource file");

--- a/JavaScriptResourceFileType.js
+++ b/JavaScriptResourceFileType.js
@@ -110,7 +110,7 @@ JavaScriptResourceFileType.prototype.newFile = function(pathName, options) {
  * @param {String} locale the name of the locale in which the resource
  * file will reside
  * @param {String} pathName the optional path to the resource file if the
- * caller has already calculated what it should be 
+ * caller has already calculated what it should be
  * @return {JavaScriptResourceFile} the Android resource file that serves the
  * given project, context, and locale.
  */

--- a/test/testJavaScriptResourceFileType.js
+++ b/test/testJavaScriptResourceFileType.js
@@ -1,7 +1,7 @@
 /*
  * testJavaScriptResourceFileType.js - test the HTML template file type handler object.
  *
- * Copyright © 2019, Box, Inc.
+ * Copyright © 2019, 2022 Box, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,23 @@ module.exports.javascriptresourcefiletype = {
         test.equal(jsrf2.getLocale(), "fr-FR");
 
         test.deepEqual(jsrf1, jsrf2);
+
+        test.done();
+    },
+
+    testJavaScriptResourceFileTypeGetResourceFileDifferentOneForDifferentPaths: function(test) {
+        test.expect(4);
+
+        var htf = new JavaScriptResourceFileType(p);
+        test.ok(htf);
+
+        var jsrf1 = htf.getResourceFile("fr-FR", "fr/FR/foo.json");
+        test.equal(jsrf1.getLocale(), "fr-FR");
+
+        var jsrf2 = htf.getResourceFile("fr-FR", "sublibrary/fr/FR/foo.json");
+        test.equal(jsrf2.getLocale(), "fr-FR");
+
+        test.notEqual(jsrf1, jsrf2);
 
         test.done();
     }


### PR DESCRIPTION
- add the ability to specify the locale to the `JavaScriptResourceFileType.newFile()` method
- add the ability to specify the path name of the caller has already calculated what it should be. This is so that the caller can implement output mappings and specify the output file name for the resource file